### PR TITLE
use Maybe for userEmail and userRole

### DIFF
--- a/src/Zendesk/User.hs
+++ b/src/Zendesk/User.hs
@@ -33,12 +33,12 @@ data User = User
   , userCreatedAt       :: Maybe UTCTime
   , userUpdatedAt       :: Maybe UTCTime
   , userTimeZone        :: Maybe Text
-  , userEmail           :: Text
+  , userEmail           :: Maybe Text
   , userPhone           :: Maybe Text
   , userLocale          :: Maybe Text
   , userLocaleId        :: Maybe Int
   , userOrganizationId  :: Maybe Int
-  , userRole            :: Text
+  , userRole            :: Maybe Text
   , userVerified        :: Maybe Bool
   , userPhoto           :: Maybe Attachment
   } deriving (Show)


### PR DESCRIPTION
Thanks for starting this library @VictorDenisov

Anyways, I got bit by bad data with missing user roles/emails.

This change will make the User type to only have the userName mandatory as per https://developer.zendesk.com/rest_api/docs/core/users
